### PR TITLE
Avoid mutable list from being used in arguments

### DIFF
--- a/ndef.py
+++ b/ndef.py
@@ -251,8 +251,8 @@ class NDEFRecord():
 
 
 class NDEFMessage():
-    def __init__(self, records=[]) -> None:
-        self.records = records
+    def __init__(self, records=None) -> None:
+        self.records = [] if not records else records
 
     def __repr__(self) -> str:
         return str(self.__dict__)


### PR DESCRIPTION
The use of an empty list as an argument causes issues. You can read up on this in https://nikos7am.com/posts/mutable-default-arguments/ .

Thanks for creating this repository, it helped me in understanding how to use NFC on CircuitPython!